### PR TITLE
only import modules if not present in current session

### DIFF
--- a/Publish-MIFunctionApp.ps1
+++ b/Publish-MIFunctionApp.ps1
@@ -22,8 +22,11 @@ param (
 
 $ErrorActionPreference = 'Stop'
 
-Import-Module -Name Az.Websites
-Import-Module -Name Az.Storage
+$requiredModules = @(
+    "Az.Websites",
+    "Az.Storage"
+)
+$requiredModules | foreach-object { if (!(get-module $_)) { import-module $_ } }
 
 #fixed strings according to MS docs
 $awjsname = 'AzureWebJobsStorage'


### PR DESCRIPTION
With this PR modules will only be loaded into the current session if they are not already imported instead of importing at every call of the ps1-script. This will decrease verbose-log output dramatically